### PR TITLE
fix: URL-encode logo paths in README for dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/docs/Transparent Logo Dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="assets/docs/Transparent Logo.png">
-    <img src="assets/docs/Transparent Logo.png" alt="Encoderize Logo" width="300">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/docs/Transparent%20Logo%20Dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/docs/Transparent%20Logo.png">
+    <img src="assets/docs/Transparent%20Logo.png" alt="Encoderize Logo" width="300">
   </picture>
 </p>
 


### PR DESCRIPTION
## Description

The dark mode logo in the README was not rendering on GitHub because the `srcset` attribute uses spaces as delimiters. The filenames (`Transparent Logo Dark.png`) contained spaces that broke the URL parsing.

Fixed by URL-encoding spaces as `%20` in the `<picture>` source paths.

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## How Has This Been Tested?
- [x] Verified logo renders correctly on GitHub in both light and dark mode